### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM golang:1.17-alpine3.15
-
-RUN apk add --no-cache \
-  ffmpeg=4.4.1-r2 \
-  curl=7.80.0-r0 \
-  bash=5.1.8-r0 \
-  tzdata=2021e-r0
+FROM golang:1.17-alpine3.15 as builder
 
 WORKDIR /go/src/github.com/joschahenningsen/TUM-Live-Worker-v2
 COPY . .
@@ -12,6 +6,15 @@ COPY . .
 RUN GO111MODULE=on go mod download
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-w -extldflags '-static'" -o /worker app/main/main.go
 
+FROM alpine:3.15
+
+RUN apk add --no-cache \
+  ffmpeg=4.4.1-r2 \
+  curl=7.80.0-r0 \
+  bash=5.1.8-r0 \
+  tzdata=2021e-r0
+
+COPY --from=builder /worker /worker
 RUN chmod +x /worker
 
 CMD ["/worker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ FROM alpine:3.15
 RUN apk add --no-cache \
   ffmpeg=4.4.1-r2 \
   curl=7.80.0-r0 \
-  bash=5.1.8-r0 \
   tzdata=2021e-r0
 
 COPY --from=builder /worker /worker

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,32 +1,32 @@
-FROM ubuntu:21.04
+FROM ubuntu:21.04 as base-image
 
 RUN apt-get -qq update && apt-get -qq upgrade
 
 ENV NGINX_VERSION nginx-1.21.4
 ENV FFMPEG_VERSION snapshot
 ENV NGINX_RTMP_MODULE_VERSION 1.2.2
-
-ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
-
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN apt-get -qq install git wget tclsh pkg-config cmake libssl-dev build-essential librtmp-dev yasm ca-certificates openssl libpcre3-dev ffmpeg
+
+FROM base-image as builder
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq install --no-install-recommends -y git wget tclsh pkg-config cmake libssl-dev build-essential librtmp-dev yasm ca-certificates openssl libpcre3-dev && \
+    apt-get clean
 
 # Install nginx.
-RUN mkdir -p /tmp/build/nginx && \
-    cd /tmp/build/nginx && \
-    wget -O ${NGINX_VERSION}.tar.gz https://nginx.org/download/${NGINX_VERSION}.tar.gz && \
-    tar -zxf ${NGINX_VERSION}.tar.gz
+WORKDIR /tmp/build/nginx
+RUN wget -O "${NGINX_VERSION}.tar.gz" "https://nginx.org/download/${NGINX_VERSION}.tar.gz" && \
+    tar -zxf "${NGINX_VERSION}.tar.gz" && \
+    rm "${NGINX_VERSION}.tar.gz"
 
 # Download and decompress RTMP module
-RUN mkdir -p /tmp/build/nginx-rtmp-module && \
-    cd /tmp/build/nginx-rtmp-module && \
-    wget -O nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz https://github.com/arut/nginx-rtmp-module/archive/v${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
-    tar -zxf nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
-    cd nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}
+WORKDIR /tmp/build/nginx-rtmp-module
+RUN wget -O "nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz" "https://github.com/arut/nginx-rtmp-module/archive/v${NGINX_RTMP_MODULE_VERSION}.tar.gz" && \
+    tar -zxf "nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz" && \
+    rm "nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz"
 
-WORKDIR /tmp/build/nginx/${NGINX_VERSION}
+WORKDIR /tmp/build/nginx/"${NGINX_VERSION}"
 RUN ./configure \
     --sbin-path=/usr/local/sbin/nginx \
     --conf-path=/etc/nginx/nginx.conf \
@@ -38,10 +38,20 @@ RUN ./configure \
     --with-http_ssl_module \
     --with-threads \
     --with-ipv6 \
-    --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} \
+    --add-module="/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}" \
     --with-cc-opt="-Wimplicit-fallthrough=0" \
     --with-debug
-RUN make -j $(getconf _NPROCESSORS_ONLN)
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
+
+FROM base-image
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq install --no-install-recommends -y tclsh make yasm ca-certificates openssl ffmpeg && \
+    apt-get clean
+
+COPY --from=builder /tmp/build/ /tmp/build/
+
+WORKDIR /tmp/build/nginx/"${NGINX_VERSION}"
 RUN make install
 WORKDIR /
 

--- a/worker/request_handlers.go
+++ b/worker/request_handlers.go
@@ -118,7 +118,7 @@ func HandleStreamEnd(ctx *StreamContext) {
 		if err != nil {
 			log.WithError(err).WithField("streamID", ctx.streamId).Warn("Can't find pgid for ffmpeg")
 		} else {
-			// We use the new pgid that we created in stream.go to actually interrupt the bash process with all its children
+			// We use the new pgid that we created in stream.go to actually interrupt the shell process with all its children
 			err := syscall.Kill(-pgid, syscall.SIGINT) // Note that the - is used to kill process groups
 			if err != nil {
 				log.WithError(err).WithField("streamID", ctx.streamId).Warn("Can't interrupt ffmpeg")

--- a/worker/stream.go
+++ b/worker/stream.go
@@ -28,14 +28,14 @@ func stream(streamCtx *StreamContext) {
 		// todo: too much duplication
 		if strings.Contains(streamCtx.sourceUrl, "rtsp") {
 			cmd = exec.Command(
-				"bash", "-c",
+				"sh", "-c",
 				`ffmpeg -hide_banner -nostats -rtsp_transport tcp -stimeout 5000000 -t `+fmt.Sprintf("%.0f", time.Until(streamUntil).Seconds())+ // timeout ffmpeg when stream is finished
 					" -i "+fmt.Sprintf(streamCtx.sourceUrl)+
 					` -map 0 -c copy -f mpegts - -c:v libx264 -preset veryfast -tune zerolatency -maxrate 2500k -bufsize 3000k -g 60 -r 30 -x264-params keyint=60:scenecut=0 -c:a aac -ar 44100 -b:a 128k `+
 					`-f flv `+fmt.Sprintf("%s/%s", streamCtx.ingestServer, streamCtx.streamName)+" >> "+streamCtx.getRecordingFileName())
 		} else {
 			cmd = exec.Command(
-				"bash", "-c",
+				"sh", "-c",
 				`ffmpeg -hide_banner -nostats -t `+fmt.Sprintf("%.0f", time.Until(streamUntil).Seconds())+ // timeout ffmpeg when stream is finished
 					" -i "+fmt.Sprintf(streamCtx.sourceUrl)+
 					` -map 0 -c copy -f mpegts - -c:v libx264 -preset veryfast -tune zerolatency -maxrate 2500k -bufsize 3000k -g 60 -r 30 -x264-params keyint=60:scenecut=0 -c:a aac -ar 44100 -b:a 128k `+


### PR DESCRIPTION
This PR optimizes the Docker images by removing unnecessary components, which should speed up deployment and reduce the attack surface.

Size comparison:
/Dockerfile: 1.22GB -> 114MB
/nginx/Dockerfile: 977MB -> 536MB

While the Nginx Docker image is already much smaller, I'm not happy with the result. Maybe we should switch to Alpine. 
Please double-check that all dependencies for production are still there (@alexanderstephan ).