### PR TITLE
Remove curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ FROM alpine:3.15
 
 RUN apk add --no-cache \
   ffmpeg=4.4.1-r2 \
-  curl=7.80.0-r0 \
   tzdata=2021e-r0
 
 COPY --from=builder /worker /worker

--- a/app/main/main.go
+++ b/app/main/main.go
@@ -30,11 +30,6 @@ func prepare() {
 	if err != nil {
 		log.Fatal("ffmpeg is not installed")
 	}
-	//check if curl is installed
-	_, err = exec.LookPath("curl")
-	if err != nil {
-		log.Fatal("curl is not installed")
-	}
 }
 
 func main() {

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -76,10 +76,10 @@ func writeFile(writer *multipart.Writer, fieldname string, file string) error {
 		return err
 	}
 	fileReader, err := os.Open(file)
-	defer fileReader.Close()
 	if err != nil {
 		return err
 	}
+	defer fileReader.Close()
 	_, err = io.Copy(formFileWriter, fileReader)
 	return err
 }

--- a/worker/upload_test.go
+++ b/worker/upload_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"github.com/joschahenningsen/TUM-Live-Worker-v2/cfg"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestUpload(t *testing.T) {
+	cfg.LrzUser = "TestUserName"
+	cfg.LrzMail = "mail@mail.de"
+	cfg.LrzPhone = "0123456789"
+	cfg.LrzSubDir = "testDir"
+	cfg.LrzUploadUrl = "http://localhost:8080/"
+	var filesize uint = 1024 // mB
+	filename, err := createDummyFile(filesize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(filename)
+
+	go post(filename)
+	var finished sync.WaitGroup
+	finished.Add(1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		defer finished.Done()
+		err := request.ParseMultipartForm(32 << 20)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			t.Fatal(err)
+			return
+		}
+		if is := request.Form["benutzer"][0]; is != cfg.LrzUser {
+			t.Fatalf("benutzer:  %v != %v", is, cfg.LrzUser)
+		}
+		if is := request.Form["mailadresse"][0]; is != cfg.LrzMail {
+			t.Fatalf("mailadresse:  %v != %v", is, cfg.LrzMail)
+		}
+		if is := request.Form["telefon"][0]; is != cfg.LrzPhone {
+			t.Fatalf("telefon:  %v != %v", is, cfg.LrzPhone)
+		}
+		if is := request.Form["unidir"][0]; is != "tum" {
+			t.Fatalf("unidir:  %v != tum", is)
+		}
+		if is := request.Form["subdir"][0]; is != cfg.LrzSubDir {
+			t.Fatalf("subdir:  %v != %v", is, cfg.LrzSubDir)
+		}
+
+		_, h, err := request.FormFile("filename")
+		if err != nil {
+			t.Fatal(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if uint(h.Size) != filesize*1<<20 {
+			t.Fatalf("incorrect size: %v", h.Size)
+		}
+		w.WriteHeader(200)
+		return
+	})
+	srv := http.Server{Addr: ":8080"}
+	defer srv.Close()
+	http.Handle("/", handler)
+	go srv.ListenAndServe()
+	finished.Wait()
+}
+
+func createDummyFile(filesize uint) (string, error) {
+	file, err := ioutil.TempFile("/tmp", "recording")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.OpenFile(file.Name(), os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	data := make([]byte, 1<<20, 1<<20)
+	for i := uint(0); i < filesize; i++ {
+		if _, err = f.Write(data); err != nil {
+			return "", err
+		}
+	}
+	return file.Name(), nil
+}

--- a/worker/upload_test.go
+++ b/worker/upload_test.go
@@ -59,7 +59,6 @@ func TestUpload(t *testing.T) {
 			t.Fatalf("incorrect size: %v", h.Size)
 		}
 		w.WriteHeader(200)
-		return
 	})
 	srv := http.Server{Addr: ":8080"}
 	defer srv.Close()
@@ -78,7 +77,7 @@ func createDummyFile(filesize uint) (string, error) {
 		return "", err
 	}
 	defer f.Close()
-	data := make([]byte, 1<<20, 1<<20)
+	data := make([]byte, 1<<20)
 	for i := uint(0); i < filesize; i++ {
 		if _, err = f.Write(data); err != nil {
 			return "", err


### PR DESCRIPTION
This PR implements lecture upload using go instead of curl. The implementation is based on: [https://stackoverflow.com/questions/59191263/how-to-upload-a-gzipped-file-without-reading-everything-into-memory](https://stackoverflow.com/questions/59191263/how-to-upload-a-gzipped-file-without-reading-everything-into-memory)

A test case was added, which uploads a dummy file to localhost:8080. Profiling the memory consumption of this test case showed that the memory consumption remains acceptable even for larger files.  

closes: #14 